### PR TITLE
add stop on side 0 functionality

### DIFF
--- a/linux-zei.go
+++ b/linux-zei.go
@@ -49,12 +49,13 @@ func main() {
 				return
 			}
 
-			if current != nil && activity == nil {
+			if current != nil && ( activity == nil || sideID == 0 ) {
 				go notification.Notify("Stopping activity", current.Activity.Name)
 				go client.StopActivity(current.Activity)
+				return
 			}
 
-			if activity != nil && current == nil {
+			if activity != nil && current == nil && sideID != 0 {
 				go notification.Notify("Starting activity", activity.Name)
 				go client.StartActivity(*activity)
 			}


### PR DESCRIPTION
Using the Zei API it appears to only be able to edit activities for sides 1 - 8 and IF other activities exist at least one of these will be set to side 0.

Thus currently placing the Zei in its stand activates whatever activity is set for side 0. For the officially supported applications this should stop the current activity. This change adds such functionality.