### PR TITLE
Avoid double slash in URLs to fix authentication

### DIFF
--- a/linux-zei.go
+++ b/linux-zei.go
@@ -13,7 +13,7 @@ func main() {
 	go RunWebserver(hub)
 
 	client := &APIClient{
-		BaseUrl: "https://api.timeular.com/api/v1/",
+		BaseUrl: "https://api.timeular.com/api/v1",
 	}
 
 	state := &Timeular{}


### PR DESCRIPTION
Looks like Timeular's API started returing weird auth tokens when signing in via https://api.timeular.com/api/v1//developer/sign-in

The token I'm getting is 147 chars long, and using it for subsequent requests results in 401 Unauthorized (no sessionToken cookie is set either).

Turns out removing the double slash from URL fixes the problem.

You can test it with a simple curl:
```
 $ curl -v -d '{"apiKey":"....","apiSecret":"...."}' \
     -H "Content-Type: application/json" -X POST \
     https://api.timeular.com/api/v1//developer/sign-in
```
vs
```
 $ curl -v -d '{"apiKey":"....","apiSecret":"...."}' \
     -H "Content-Type: application/json" -X POST \
     https://api.timeular.com/api/v1/developer/sign-in
```